### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,3 @@ boto3
 botocore
 pathlib
 argparse
-csv


### PR DESCRIPTION
csv is a built in module so this requirements.txt causes "pip install -r requirements.txt" to fail.